### PR TITLE
Optimizations

### DIFF
--- a/tumorsphere/cells.py
+++ b/tumorsphere/cells.py
@@ -201,20 +201,18 @@ class Cell:
 
         Returns
         -------
-        List[Cell]
-            A list of `Cell` objects that are neighbors of the current cell up
+        Set[Cell]
+            A set of `Cell` objects that are neighbors of the current cell up
             to the second degree.
         """
         neighbors_up_to_second_degree = set(self.neighbors)
         for cell1 in self.neighbors:
-            neighbors_up_to_second_degree = (
-                neighbors_up_to_second_degree.union(set(cell1.neighbors))
+            new_neighbors = set(cell1.neighbors).difference(
+                neighbors_up_to_second_degree
             )
-            for cell2 in cell1.neighbors:
-                neighbors_up_to_second_degree = (
-                    neighbors_up_to_second_degree.union(set(cell2.neighbors))
-                )
-        neighbors_up_to_second_degree = list(neighbors_up_to_second_degree)
+            neighbors_up_to_second_degree.update(new_neighbors)
+            for cell2 in new_neighbors:
+                neighbors_up_to_second_degree.update(set(cell2.neighbors))
         return neighbors_up_to_second_degree
 
     def get_list_of_neighbors_up_to_third_degree(self):
@@ -226,26 +224,23 @@ class Cell:
 
         Returns
         -------
-        List[Cell]
-            A list of `Cell` objects that are neighbors of the current cell up
+        Set[Cell]
+            A set of `Cell` objects that are neighbors of the current cell up
             to the third degree.
         """
         neighbors_up_to_third_degree = set(self.neighbors)
         for cell1 in self.neighbors:
-            neighbors_up_to_third_degree = neighbors_up_to_third_degree.union(
-                set(cell1.neighbors)
+            new_neighbors = set(cell1.neighbors).difference(
+                neighbors_up_to_third_degree
             )
-            for cell2 in cell1.neighbors:
-                neighbors_up_to_third_degree = (
-                    neighbors_up_to_third_degree.union(set(cell2.neighbors))
+            neighbors_up_to_third_degree.update(new_neighbors)
+            for cell2 in new_neighbors:
+                new_neighbors_l2 = set(cell2.neighbors).difference(
+                    neighbors_up_to_third_degree
                 )
-                for cell3 in cell2.neighbors:
-                    neighbors_up_to_third_degree = (
-                        neighbors_up_to_third_degree.union(
-                            set(cell3.neighbors)
-                        )
-                    )
-        neighbors_up_to_third_degree = list(neighbors_up_to_third_degree)
+                neighbors_up_to_third_degree.update(new_neighbors_l2)
+                for cell3 in new_neighbors_l2:
+                    neighbors_up_to_third_degree.update(set(cell3.neighbors))
         return neighbors_up_to_third_degree
 
     def find_neighbors(self):

--- a/tumorsphere/cells.py
+++ b/tumorsphere/cells.py
@@ -23,6 +23,9 @@ class Cell:
         A vector with 3 components representing the position of the cell.
     culture : tumorsphere.Culture
         The culture to which the cell belongs.
+    rng : numpy.random.Generator
+        The random number generator used by the cell. In most
+        cases, this should be left to be managed by the culture.
     adjacency_threshold : float, optional
         The maximum distance between cells for them to be considered neighbors.
         Defaults to 4, but is inherited from cell to cell (so the first cell
@@ -47,9 +50,6 @@ class Cell:
         and if it doesn't happen at prob_diff = 0, it will never happen).
     continuous_graph_generation : bool
         True if the cell should continuously generate a graph of its neighbors, False otherwise.
-    rng_seed : int, optional
-        The seed for the random number generator used by the cell. In most
-        cases, this should be left to be managed by the parent cell.
 
     Attributes
     ----------
@@ -76,7 +76,7 @@ class Cell:
         scratch.
     find_neighbors_from_entire_culture()
         Find neighboring cells from the entire culture, keeping the current
-        cells in the list.
+        cells in the set.
     get_neighbors_up_to_second_degree()
         Get the set of neighbors up to second degree.
     get_neighbors_up_to_third_degree()
@@ -84,7 +84,7 @@ class Cell:
         to the third degree.
     find_neighbors()
         Find neighboring cells from the neighbors of the current cell up
-        to some degree, keeping the current cells in the list.
+        to some degree, keeping the current cells in the set.
     find_neighbors_from_scratch()
         Find neighboring cells from the neighbors of the current cell up
         to some degree, re-calculating from scratch.
@@ -152,17 +152,17 @@ class Cell:
     def find_neighbors_from_entire_culture_from_scratch(self) -> None:
         """Find neighboring cells from the entire culture, re-calculating from scratch.
 
-        This method clears the current neighbor list and calculates a new neighbor list
+        This method clears the current neighbor set and calculates a new neighbor set
         for the current cell, iterating over all cells in the culture. For each cell,
-        it checks if it is not the current cell and not already in the neighbor list,
+        it checks if it is not the current cell and not already in the neighbor set,
         and if it is within the adjacency threshold. If all conditions are met, the
-        cell is added to the neighbor list.
+        cell is added to the neighbor set.
 
         Returns:
             None
         """
         self.neighbors = set()
-        # si las células se mueven, hay que calcular toda la lista de cero
+        # si las células se mueven, hay que calcular todo el conjunto de cero
         for cell in self.culture.cells:
             neither_self_nor_neighbor: bool = (cell is not self) and (
                 cell not in self.neighbors
@@ -177,19 +177,19 @@ class Cell:
 
     def find_neighbors_from_entire_culture(self) -> None:
         """Find neighboring cells from the entire culture, keeping the current
-        cells in the list.
+        cells in the set.
 
-        This method keeps and updates the neighbor list for the current cell,
+        This method keeps and updates the neighbor set for the current cell,
         by looking at all cells in the culture. For each cell, it checks if
-        it is not the current cell and not already in the neighbor list, and
+        it is not the current cell and not already in the neighbor set, and
         if it is within the adjacency threshold. If all conditions are met,
-        the cell is added to the neighbor list.
+        the cell is added to the neighbor set.
 
         Returns:
             None
         """
         # como las células no se mueven, sólo se pueden agregar vecinos, por
-        # lo que no hay necesidad de reiniciar la lista, sólo añadimos
+        # lo que no hay necesidad de reiniciar el conjunto, sólo añadimos
         # los posibles nuevos vecinos
         for cell in self.culture.cells:
             neither_self_nor_neighbor: bool = (cell is not self) and (
@@ -230,7 +230,7 @@ class Cell:
         """Returns the set of cells that are neighbors of the current cell up
         to the third degree.
 
-        This method returns a list of unique cells that are neighbors to the
+        This method returns a set of unique cells that are neighbors to the
         cell, or neighbors of neighbors, recurrently up to third degree.
 
         Returns
@@ -256,14 +256,14 @@ class Cell:
 
     def find_neighbors(self) -> None:
         """Find neighboring cells from the neighbors of the current cell up
-        to some degree, keeping the current cells in the list.
+        to some degree, keeping the current cells in the set.
 
-        This method keeps and updates the neighbor list for the current cell,
+        This method keeps and updates the neighbor set for the current cell,
         by looking recursively at neighbors of the cell, up to certain degree.
         For each cell, it checks if it is not the current cell and not already
-        in the neighbor list, and if it is within the adjacency threshold. If
-        all conditions are met, the cell is added to the neighbor list.
-        If the list of neighbors has less than 12 cells, we look up to third
+        in the neighbor set, and if it is within the adjacency threshold. If
+        all conditions are met, the cell is added to the neighbor set.
+        If the set of neighbors has less than 12 cells, we look up to third
         neighbors, if not, just up to second neighbors. This decision stems
         from the fact that if the cell is a newborn, it will only have its
         parent as a neighbor, so the neighbors of its neighbors are just the
@@ -298,12 +298,12 @@ class Cell:
         """Find neighboring cells from the neighbors of the current cell up
         to some degree, re-calculating from scratch.
 
-        This method clears and re-calculates the neighbor list for the current
+        This method clears and re-calculates the neighbor set for the current
         cell, by looking recursively at neighbors of the cell, up to certain
         degree. For each cell, it checks if it is not the current cell and not
-        already in the neighbor list, and if it is within the adjacency
+        already in the neighbor set, and if it is within the adjacency
         threshold. If all conditions are met, the cell is added to the
-        neighbor list. If the list of neighbors has less than 12 cells, we
+        neighbor set. If the set of neighbors has less than 12 cells, we
         look up to third neighbors, if not, just up to second neighbors. This
         decision stems from the fact that if the cell is a newborn, it will
         only have its parent as a neighbor, so the neighbors of its neighbors
@@ -321,9 +321,9 @@ class Cell:
             neighbors_up_to_certain_degree = (
                 self.get_neighbors_up_to_second_degree()
             )
-        # we reset the neighbors list
+        # we reset the neighbors set
         self.neighbors = set()
-        # we add the cells to the list
+        # we add the cells to the set
         for cell in neighbors_up_to_certain_degree:
             neither_self_nor_neighbor = (cell is not self) and (
                 cell not in self.neighbors

--- a/tumorsphere/cells.py
+++ b/tumorsphere/cells.py
@@ -386,13 +386,19 @@ class Cell:
                 neighbors_up_to_second_degree = (
                     self.get_neighbors_up_to_second_degree()
                 )
+                cell_positions = [
+                    cell.position for cell in neighbors_up_to_second_degree
+                ]
+
                 # array with the distances from the proposed child position to the other cells
-                distance = np.array(
-                    [
-                        np.linalg.norm(child_position - cell.position)
-                        for cell in neighbors_up_to_second_degree
-                    ]
-                )
+                if len(neighbors_up_to_second_degree) > 0:
+                    cell_positions_mat = np.stack(cell_positions)
+                    distance = np.linalg.norm(
+                        child_position - cell_positions_mat, axis=1
+                    )
+                else:
+                    distance = np.array([])
+
                 # boolean array specifying if there is no overlap between
                 # the proposed child position and the other cells
                 no_overlap = np.all(distance >= 2 * self.radius)

--- a/tumorsphere/cells.py
+++ b/tumorsphere/cells.py
@@ -96,6 +96,7 @@ class Cell:
 
     position: np.ndarray
     # culture: Culture
+    rng: np.random.Generator
     adjacency_threshold: float
     radius: float
     is_stem: bool
@@ -103,7 +104,6 @@ class Cell:
     prob_stem: float
     prob_diff: float
     continuous_graph_generation: bool
-    rng_seed: np.int64
     _swap_probability: float
     _colors: Dict[Tuple[bool, bool], str]
     neighbors: Set["Cell"]
@@ -113,6 +113,7 @@ class Cell:
         self,
         position: np.ndarray,
         culture,  # : Culture,
+        rng: np.random.Generator,
         adjacency_threshold: float = 4,  # 2.83 approx 2*np.sqrt(2), hcp second neighbor distance
         radius: float = 1,
         is_stem: bool = False,
@@ -120,14 +121,11 @@ class Cell:
         prob_stem: float = 0.36,  # Wang HARD substrate value
         prob_diff: float = 0,
         continuous_graph_generation: bool = False,
-        rng_seed: np.int64 = np.int64(23978461273864)
-        # THE CULTURE MUST PROVIDE A SEED
-        # in spite of the fact that I set a default
-        # (so the code doesn't break e.g. when testing)
     ) -> None:
         # Generic attributes
         self.position = position  # NumPy array, vector with 3 components
         self.culture = culture
+        self.rng = rng
         self.adjacency_threshold = adjacency_threshold
         self.radius = radius  # radius of cell
         self.max_repro_attempts = max_repro_attempts
@@ -136,9 +134,6 @@ class Cell:
         self.prob_stem = prob_stem
         self.prob_diff = prob_diff
         self._swap_probability = 0.5
-
-        # We instantiate the cell's RNG with the entropy provided
-        self.rng = np.random.default_rng(rng_seed)
 
         # Plotting and graph related attributes
         self._continuous_graph_generation = continuous_graph_generation
@@ -417,6 +412,7 @@ class Cell:
                         child_cell = Cell(
                             position=child_position,
                             culture=self.culture,
+                            rng=self.rng,
                             adjacency_threshold=self.adjacency_threshold,
                             radius=self.radius,
                             is_stem=True,
@@ -424,14 +420,12 @@ class Cell:
                             prob_stem=self.prob_stem,
                             prob_diff=self.prob_diff,
                             continuous_graph_generation=self._continuous_graph_generation,
-                            rng_seed=np.int64(
-                                self.rng.integers(low=2**20, high=2**50)
-                            ),
                         )
                     else:
                         child_cell = Cell(
                             position=child_position,
                             culture=self.culture,
+                            rng=self.rng,
                             adjacency_threshold=self.adjacency_threshold,
                             radius=self.radius,
                             is_stem=False,
@@ -439,9 +433,6 @@ class Cell:
                             prob_stem=self.prob_stem,
                             prob_diff=self.prob_diff,
                             continuous_graph_generation=self._continuous_graph_generation,
-                            rng_seed=np.int64(
-                                self.rng.integers(low=2**20, high=2**50)
-                            ),
                         )
                         if random_number <= (
                             self.prob_stem + self.prob_diff
@@ -456,6 +447,7 @@ class Cell:
                     child_cell = Cell(
                         position=child_position,
                         culture=self.culture,
+                        rng=self.rng,
                         adjacency_threshold=self.adjacency_threshold,
                         radius=self.radius,
                         is_stem=False,
@@ -463,9 +455,6 @@ class Cell:
                         prob_stem=self.prob_stem,
                         prob_diff=self.prob_diff,
                         continuous_graph_generation=self._continuous_graph_generation,
-                        rng_seed=np.int64(
-                            self.rng.integers(low=2**20, high=2**50)
-                        ),
                     )
                 # we add this cell to the culture's cells and active_cells lists
                 self.culture.cells.append(child_cell)

--- a/tumorsphere/culture.py
+++ b/tumorsphere/culture.py
@@ -121,6 +121,7 @@ class Culture:
         first_cell_object = Cell(
             position=np.array([0, 0, 0]),
             culture=self,
+            rng=self.rng,
             adjacency_threshold=self.adjacency_threshold,
             radius=self.cell_radius,
             is_stem=self.first_cell_is_stem,
@@ -128,7 +129,6 @@ class Culture:
             prob_stem=self.prob_stem,
             prob_diff=self.prob_diff,
             continuous_graph_generation=continuous_graph_generation,
-            rng_seed=self.rng.integers(low=2**20, high=2**50),
         )
 
         # we initialize the lists and graphs with the first cell


### PR DESCRIPTION
- Modify `Cell.get_neighbors_up_to_*_degree` to skip visited cells (i.e. implement breadth-first search)
- Stack neighbor cell positions and call `numpy.linalg.norm` once
- Use a single RNG per culture

This is about 10x faster than current code. More than half of the CPU time after these optimizations lies in stacking neighbor positions before calling `norm`, so there's another easy 2x speedup left in the tank.