### PR TITLE
Output refactoring

### DIFF
--- a/tumorsphere/core/cells.py
+++ b/tumorsphere/core/cells.py
@@ -107,32 +107,12 @@ class Cell:
 
         # if we're simulating with the SQLite DB, we insert a register in the
         # Cells table of the SQLite DB
-        if culture.conn is not None:
-            with culture.conn:
-                cursor = culture.conn.cursor()
-                cursor.execute(
-                    """
-                    INSERT INTO Cells (_index, parent_index, position_x, position_y, position_z, t_creation, culture_id)
-                    VALUES (?, ?, ?, ?, ?, ?, ?);
-                """,
-                    (
-                        self._index,
-                        int(self.parent_index),
-                        self.culture.cell_positions[self._index][0],
-                        self.culture.cell_positions[self._index][1],
-                        self.culture.cell_positions[self._index][2],
-                        creation_time,
-                        self.culture.culture_id,
-                    ),
-                )
-                cursor.execute(
-                    """
-                    INSERT INTO StemChanges (cell_id, t_change, is_stem)
-                    VALUES (?, ?, ?);
-                """,
-                    (
-                        self._index,
-                        creation_time,
-                        self.is_stem,
-                    ),
-                )
+        self.culture.output.record_cell(
+            self._index,
+            int(self.parent_index),
+            self.culture.cell_positions[self._index][0],
+            self.culture.cell_positions[self._index][1],
+            self.culture.cell_positions[self._index][2],
+            creation_time,
+            self.is_stem,
+        )

--- a/tumorsphere/core/culture.py
+++ b/tumorsphere/core/culture.py
@@ -12,11 +12,13 @@ from typing import Set
 import numpy as np
 
 from tumorsphere.core.cells import Cell
+from tumorsphere.core.output import TumorsphereOutput
 
 
 class Culture:
     def __init__(
         self,
+        output: TumorsphereOutput,
         adjacency_threshold: float = 4,
         cell_radius: float = 1,
         cell_max_repro_attempts: int = 1000,
@@ -101,8 +103,7 @@ class Culture:
         # time at wich the culture was created
         self.simulation_start = self._get_simulation_time()
 
-        # connection to the SQLite database (defined while simulating)
-        self.conn = None
+        self.output = output
 
     # ----------------database related behavior----------------
 
@@ -112,108 +113,6 @@ class Culture:
         # we format the string
         time_string = current_time.strftime("%Y-%m-%d %H:%M:%S")
         return time_string
-
-    def _create_tables(self):
-        with self.conn:
-            cursor = self.conn.cursor()
-
-            # Enable foreign key constraints for this connection
-            cursor.execute("PRAGMA foreign_keys = ON;")
-
-            # Creating the Culture table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS Cultures (
-                    culture_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    prob_stem REAL NOT NULL,
-                    prob_diff REAL NOT NULL,
-                    culture_seed INTEGER NOT NULL,
-                    simulation_start TIMESTAMP NOT NULL,
-                    adjacency_threshold REAL NOT NULL,
-                    swap_probability REAL NOT NULL
-                );
-            """
-            )
-
-            # Creating the Cells table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS Cells (
-                _index INTEGER PRIMARY KEY,
-                parent_index INTEGER,
-                position_x REAL NOT NULL,
-                position_y REAL NOT NULL,
-                position_z REAL NOT NULL,
-                t_creation INTEGER NOT NULL,
-                t_deactivation INTEGER,
-                culture_id INTEGER,
-                FOREIGN KEY(culture_id) REFERENCES Cultures(culture_id)
-            );
-            """
-            )
-
-            # Creating the StemChange table
-            cursor.execute(
-                """
-                CREATE TABLE IF NOT EXISTS StemChanges (
-                change_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                cell_id INTEGER NOT NULL,
-                t_change INTEGER NOT NULL,
-                is_stem BOOLEAN NOT NULL,
-                FOREIGN KEY(cell_id) REFERENCES Cells(_index)
-            );
-            """
-            )
-
-    def _insert_culture_record_and_get_culture_id(self):
-        with self.conn:
-            cursor = self.conn.cursor()
-            cursor.execute(
-                """
-                INSERT INTO Cultures (prob_stem, prob_diff, culture_seed, simulation_start, adjacency_threshold, swap_probability)
-                VALUES (?, ?, ?, ?, ?, ?);
-            """,
-                (
-                    self.prob_stem,
-                    self.prob_diff,
-                    int(self.rng_seed),
-                    self.simulation_start,
-                    self.adjacency_threshold,
-                    self.swap_probability,
-                ),
-            )
-            culture_id = cursor.lastrowid
-            return culture_id
-
-    def record_stemness(self, cell_index, tic):
-        with self.conn:
-            cursor = self.conn.cursor()
-            stemness = self.cells[cell_index].is_stem
-            cursor.execute(
-                """
-                INSERT INTO StemChanges (cell_id, t_change, is_stem)
-                VALUES (?, ?, ?);
-            """,
-                (
-                    int(cell_index),
-                    tic,
-                    stemness,
-                ),
-            )
-
-    def record_deactivation(self, cell_index, tic):
-        with self.conn:
-            cursor = self.conn.cursor()
-
-            # Recording (updating) the t_deactivation value for the specified cell
-            cursor.execute(
-                """
-                UPDATE Cells
-                SET t_deactivation = ?
-                WHERE _index = ?;
-                """,
-                (tic, int(cell_index)),
-            )
 
     # ------------------cell related behavior------------------
 
@@ -351,9 +250,7 @@ class Culture:
         new_position = cell_position + np.array([x, y, z])
         return new_position
 
-    def reproduce(
-        self, cell_index: int, tic: int, dat_files: bool = False
-    ) -> None:
+    def reproduce(self, cell_index: int, tic: int) -> None:
         """The given cell reproduces, generating a new child cell.
 
         Attempts to create a new cell in a random position, adjacent to the
@@ -401,7 +298,7 @@ class Culture:
                 # every element of the array, we break the loop
                 if no_overlap:
                     break
-            
+
             # if there was no overlap, we create a child in that position
             # if not, we do nothing but specifying that there is no available
             # space
@@ -429,17 +326,20 @@ class Culture:
                             self.prob_stem + self.prob_diff
                         ):  # pd
                             cell.is_stem = False
-                            if not dat_files:
-                                self.record_stemness(cell_index, tic)
+                            self.output.record_stemness(
+                                cell_index, tic, cell.is_stem
+                            )
                         elif (
                             self.rng.random() <= self.swap_probability
                         ):  # pa = 1-ps-pd
                             cell.is_stem = False
-                            if not dat_files:
-                                self.record_stemness(cell_index, tic)
+                            self.output.record_stemness(
+                                cell_index, tic, cell.is_stem
+                            )
                             child_cell.is_stem = True
-                            if not dat_files:
-                                self.record_stemness(child_cell._index, tic)
+                            self.output.record_stemness(
+                                child_cell._index, tic, child_cell.is_stem
+                            )
                 else:
                     child_cell = Cell(
                         position=child_position,
@@ -469,8 +369,7 @@ class Culture:
                 # lista.
                 # Opcción 3: poner un raise error si el index sigue estando
                 # en la lista de active_cell_indexes (mejor implementar un test).
-                if not dat_files:
-                    self.record_deactivation(cell_index, tic)
+                self.output.record_deactivation(cell_index, tic)
                 # if there was no available space, we turn off reproduction
                 # and record the change in the Cells table of the DataBase
         # else:
@@ -480,7 +379,7 @@ class Culture:
 
     # ---------------------------------------------------------
 
-    def simulate(self, num_times: int, culture_name: str) -> None:
+    def simulate(self, num_times: int) -> None:
         """Simulate culture growth for a specified number of time steps.
 
         At each time step, we randomly sort the list of active cells and then
@@ -491,32 +390,20 @@ class Culture:
         ----------
         num_times : int
             The number of time steps to simulate the cellular automaton.
-        culture_name : str
-            The name of the culture in the simulation, in the format
-            culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}.dat
         """
-
-        # connection to the SQLite database
-        # we connect into a 'data' directory, if not present, we warn
-        # and connect to a db in the current folder
-        # self.conn = sqlite3.connect(f"data/{culture_name}.db")
-        try:
-            self.conn = sqlite3.connect(f"data/{culture_name}.db")
-        except sqlite3.OperationalError:
-            print(
-                "The 'data' directory does not exist. The database will be "
-                "created in the current folder."
-            )
-            self.conn = sqlite3.connect(f"{culture_name}.db")
 
         # if the culture is brand-new, we create the tables of the DB and the
         # first cell
         if len(self.cells) == 0:
-            # we create the tables of the DB
-            self._create_tables()
-
             # we insert the register corresponding to this culture
-            self.culture_id = self._insert_culture_record_and_get_culture_id()
+            self.output.begin_culture(
+                self.prob_stem,
+                self.prob_diff,
+                self.rng_seed,
+                self.simulation_start,
+                self.adjacency_threshold,
+                self.swap_probability,
+            )
 
             # we instantiate the first cell
             first_cell_object = Cell(
@@ -527,6 +414,16 @@ class Culture:
                 available_space=True,
             )
 
+        # we count the initial amount of CSCs
+        if self.first_cell_is_stem:
+            initial_amount_of_csc = 1
+        else:
+            initial_amount_of_csc = 0
+
+        self.output.record_num_cells(
+            1, 1, initial_amount_of_csc, initial_amount_of_csc
+        )
+
         # we simulate for num_times time steps
         for i in range(1, num_times):
             # we get a permuted copy of the cells list
@@ -535,63 +432,10 @@ class Culture:
             )
             # and reproduce the cells in this random order
             for index in active_cell_indexes:
-                self.reproduce(cell_index=index, tic=i, dat_files=False)
+                self.reproduce(cell_index=index, tic=i)
 
-    def simulate_with_dat_files(
-        self, num_times: int, culture_name: str
-    ) -> None:
-        """Simulate culture growth for a specified number of time steps and
-        record the data in a file at each time step, so its available in real
-        time.
-
-        At each time step, we randomly sort the list of active cells and then
-        we tell them to reproduce one by one. The data that gets recorded at
-        each step is the total number of cells, the number of active cells,
-        the number of stem cells, and the number of active stem cells. It no
-        longer saves data in a dictionary, but rather to a file with a
-        specified name.
-
-        Parameters
-        ----------
-        num_times : int
-            The number of time steps to simulate the cellular automaton.
-        culture_name : str
-            The name of the culture in the simulation, in the format
-            culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}.dat
-        """
-
-        # we instantiate the first cell
-        first_cell_object = Cell(
-            position=np.array([0, 0, 0]),
-            culture=self,
-            is_stem=self.first_cell_is_stem,
-            parent_index=0,
-            available_space=True,
-        )
-
-        # we count the initial amount of CSCs
-        if self.first_cell_is_stem:
-            initial_amount_of_csc = 1
-        else:
-            initial_amount_of_csc = 0
-
-        # we write the header and the data values for this time step
-        with open(f"data/{culture_name}.dat", "w") as file:
-            file.write("total, active, total_stem, active_stem \n")
-            file.write(
-                f"1, 1, {initial_amount_of_csc}, {initial_amount_of_csc} \n"
-            )
-
-        # we simulate for num_times time steps
-        for i in range(1, num_times):
-            # we get a permuted copy of the cells list
-            active_cell_indexes = self.rng.permutation(
-                self.active_cell_indexes
-            )
-            # I had to point to the cells in a copied list,
-            # if not, strange things happened
-            for index in active_cell_indexes:
-                self.reproduce(cell_index=index, tic=i, dat_files=True)
+            # we save the data for ovito
+            self.output.dump_cell_positions(i, self.cells, self.cell_positions)
 
             # we count the number of CSCs in this time step
             total_stem_counter = 0
@@ -606,117 +450,9 @@ class Culture:
                     active_stem_counter = active_stem_counter + 1
 
             # we save the data to a file
-            with open(f"data/{culture_name}.dat", "a") as file:
-                file.write(
-                    f"{len(self.cells)}, {len(self.active_cell_indexes)}, {total_stem_counter}, {active_stem_counter} \n"
-                )
-
-    def simulate_with_ovito_data(
-        self, num_times: int, culture_name: str
-    ) -> None:
-        """Idem to simulate_with_persistent_data, but saving data for plotting
-        with ovito.
-
-        Parameters
-        ----------
-        num_times : int
-            The number of time steps to simulate the cellular automaton.
-        culture_name : str
-            The name of the culture in the simulation, in the format
-            culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}.dat
-        """
-
-        # we instantiate the first cell
-        first_cell_object = Cell(
-            position=np.array([0, 0, 0]),
-            culture=self,
-            is_stem=self.first_cell_is_stem,
-            parent_index=0,
-            available_space=True,
-        )
-
-        # we simulate for num_times time steps
-        for i in range(1, num_times):
-            # we get a permuted copy of the cells list
-            active_cell_indexes = self.rng.permutation(
-                self.active_cell_indexes
+            self.output.record_num_cells(
+                len(self.cells),
+                len(self.active_cell_indexes),
+                total_stem_counter,
+                active_stem_counter,
             )
-            # I had to point to the cells in a copied list,
-            # if not, strange things happened
-            for index in active_cell_indexes:
-                self.reproduce(index)
-
-            # we save the data for ovito
-            self.make_ovito_data_file(t=i, culture_name=culture_name)
-
-    def make_ovito_data_file(self, t, culture_name):
-        """Writes the data file in path for ovito, for time step t of self.
-        Auxiliar function for simulate_with_ovito_data.
-        """
-        path_to_write = f"ovito_data_{culture_name}.{t:03}"
-        with open(path_to_write, "w") as file_to_write:
-            file_to_write.write(str(len(self.cells)) + "\n")
-            file_to_write.write(
-                ' Lattice="1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"Properties=species:S:1:pos:R:3:Color:r:1'
-                + "\n"
-            )
-
-            for cell in self.cells:  # csc activas
-                if cell.is_stem and cell.available_space:
-                    line = (
-                        "active_stem "
-                        + str(self.cell_positions[cell._index][0])
-                        + " "
-                        + str(self.cell_positions[cell._index][1])
-                        + " "
-                        + str(self.cell_positions[cell._index][2])
-                        + " "
-                        + "1"
-                        + "\n"
-                    )
-                    file_to_write.write(line)
-
-            for cell in self.cells:  # csc quiesc
-                if cell.is_stem and (not cell.available_space):
-                    line = (
-                        "quiesc_stem "
-                        + str(self.cell_positions[cell._index][0])
-                        + " "
-                        + str(self.cell_positions[cell._index][1])
-                        + " "
-                        + str(self.cell_positions[cell._index][2])
-                        + " "
-                        + "2"
-                        + "\n"
-                    )
-                    file_to_write.write(line)
-
-            for cell in self.cells:  # dcc activas
-                if (not cell.is_stem) and cell.available_space:
-                    line = (
-                        "active_diff "
-                        + str(self.cell_positions[cell._index][0])
-                        + " "
-                        + str(self.cell_positions[cell._index][1])
-                        + " "
-                        + str(self.cell_positions[cell._index][2])
-                        + " "
-                        + "3"
-                        + "\n"
-                    )
-                    file_to_write.write(line)
-
-            for cell in self.cells:  # dcc quiesc
-                if not (cell.is_stem or cell.available_space):
-                    line = (
-                        "quiesc_diff "
-                        + str(self.cell_positions[cell._index][0])
-                        + " "
-                        + str(self.cell_positions[cell._index][1])
-                        + " "
-                        + str(self.cell_positions[cell._index][2])
-                        + " "
-                        + "4"
-                        + "\n"
-                    )
-                    file_to_write.write(line)

--- a/tumorsphere/core/culture.py
+++ b/tumorsphere/core/culture.py
@@ -5,7 +5,6 @@ Classes:
     - Culture: Class that represents a culture of cells. Usually dependent
     on the Simulation class.
 """
-import sqlite3
 from datetime import datetime
 from typing import Set
 

--- a/tumorsphere/core/output.py
+++ b/tumorsphere/core/output.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 import sqlite3
 import logging
-import os
 
 
 class TumorsphereOutput(ABC):

--- a/tumorsphere/core/output.py
+++ b/tumorsphere/core/output.py
@@ -1,0 +1,419 @@
+from abc import ABC, abstractmethod
+
+import sqlite3
+import logging
+import os
+
+
+class TumorsphereOutput(ABC):
+    @abstractmethod
+    def begin_culture(
+        self,
+        prob_stem,
+        prob_diff,
+        rng_seed,
+        simulation_start,
+        adjacency_threshold,
+        swap_probability,
+    ):
+        pass
+
+    @abstractmethod
+    def record_stemness(self, cell_index, tic, stemness):
+        pass
+
+    @abstractmethod
+    def record_deactivation(self, cell_index, tic):
+        pass
+
+    @abstractmethod
+    def record_num_cells(
+        self, num_cells, num_active, num_stem, num_active_stem
+    ):
+        pass
+
+    # FIXME: These two are redundant
+    @abstractmethod
+    def dump_cell_positions(self, t, cells, cell_positions):
+        pass
+
+    @abstractmethod
+    def record_cell(
+        self, index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+    ):
+        pass
+
+
+class OutputDemux(TumorsphereOutput):
+    def __init__(self, culture_name, result_list):
+        self.culture_name = culture_name
+        self.result_list = result_list
+
+    def begin_culture(
+        self,
+        prob_stem,
+        prob_diff,
+        rng_seed,
+        simulation_start,
+        adjacency_threshold,
+        swap_probability,
+    ):
+        for result in self.result_list:
+            result.begin_culture(
+                prob_stem,
+                prob_diff,
+                rng_seed,
+                simulation_start,
+                adjacency_threshold,
+                swap_probability,
+            )
+
+    def record_stemness(self, cell_index, tic, stemness):
+        for result in self.result_list:
+            result.record_stemness(cell_index, tic, stemness)
+
+    def record_deactivation(self, cell_index, tic):
+        for result in self.result_list:
+            result.record_deactivation(cell_index, tic)
+
+    def record_num_cells(
+        self, num_cells, num_active, num_stem, num_active_stem
+    ):
+        for result in self.result_list:
+            result.record_num_cells(
+                num_cells, num_active, num_stem, num_active_stem
+            )
+
+    def dump_cell_positions(self, t, cells, cell_positions):
+        for result in self.result_list:
+            result.dump_cell_positions(t, cells, cell_positions)
+
+    def record_cell(
+        self, index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+    ):
+        for result in self.result_list:
+            result.record_cell(
+                index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+            )
+
+
+class SQLOutput(TumorsphereOutput):
+    def __init__(self, culture_name):
+        # connection to the SQLite database
+        # we connect into a 'data' directory, if not present, we warn
+        # and connect to a db in the current folder
+        self.conn = None
+        try:
+            self.conn = sqlite3.connect(f"data/{culture_name}.db")
+        except sqlite3.OperationalError:
+            print(
+                "The 'data' directory does not exist. The database will be "
+                "created in the current folder."
+            )
+            self.conn = sqlite3.connect(f"{culture_name}.db")
+
+        cursor = self.conn.cursor()
+
+        # Enable foreign key constraints for this connection
+        cursor.execute("PRAGMA foreign_keys = ON;")
+
+        # Creating the Culture table
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS Cultures (
+                culture_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                prob_stem REAL NOT NULL,
+                prob_diff REAL NOT NULL,
+                culture_seed INTEGER NOT NULL,
+                simulation_start TIMESTAMP NOT NULL,
+                adjacency_threshold REAL NOT NULL,
+                swap_probability REAL NOT NULL
+            );
+            """
+        )
+        # Creating the Cells table
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS Cells (
+            _index INTEGER PRIMARY KEY,
+            parent_index INTEGER,
+            position_x REAL NOT NULL,
+            position_y REAL NOT NULL,
+            position_z REAL NOT NULL,
+            t_creation INTEGER NOT NULL,
+            t_deactivation INTEGER,
+            culture_id INTEGER,
+            FOREIGN KEY(culture_id) REFERENCES Cultures(culture_id)
+            );
+            """
+        )
+        # Creating the StemChange table
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS StemChanges (
+            change_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cell_id INTEGER NOT NULL,
+            t_change INTEGER NOT NULL,
+            is_stem BOOLEAN NOT NULL,
+            FOREIGN KEY(cell_id) REFERENCES Cells(_index)
+            );
+            """
+        )
+
+    def begin_culture(
+        self,
+        prob_stem,
+        prob_diff,
+        rng_seed,
+        simulation_start,
+        adjacency_threshold,
+        swap_probability,
+    ) -> int:
+        with self.conn:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO Cultures (prob_stem, prob_diff, culture_seed, simulation_start, adjacency_threshold, swap_probability)
+                VALUES (?, ?, ?, ?, ?, ?);
+            """,
+                (
+                    prob_stem,
+                    prob_diff,
+                    int(rng_seed),
+                    simulation_start,
+                    adjacency_threshold,
+                    swap_probability,
+                ),
+            )
+            self.culture_id = cursor.lastrowid
+
+    def record_stemness(self, cell_index, tic, stemness):
+        with self.conn:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO StemChanges (cell_id, t_change, is_stem)
+                VALUES (?, ?, ?);
+            """,
+                (
+                    int(cell_index),
+                    tic,
+                    stemness,
+                ),
+            )
+
+    def record_deactivation(self, cell_index, tic):
+        with self.conn:
+            cursor = self.conn.cursor()
+
+            # Recording (updating) the t_deactivation value for the specified cell
+            cursor.execute(
+                """
+                UPDATE Cells
+                SET t_deactivation = ?
+                WHERE _index = ?;
+                """,
+                (tic, int(cell_index)),
+            )
+
+    def record_num_cells(
+        self, num_cells, num_active, num_stem, num_active_stem
+    ):
+        pass
+
+    def dump_cell_positions(self, t, cells, cell_positions):
+        pass
+
+    def record_cell(
+        self, index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+    ):
+        with self.conn:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO Cells (_index, parent_index, position_x, position_y, position_z, t_creation, culture_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?);
+            """,
+                (
+                    index,
+                    parent,
+                    pos_x,
+                    pos_y,
+                    pos_z,
+                    creation_time,
+                    self.culture_id,
+                ),
+            )
+            cursor.execute(
+                """
+                INSERT INTO StemChanges (cell_id, t_change, is_stem)
+                VALUES (?, ?, ?);
+            """,
+                (
+                    index,
+                    creation_time,
+                    is_stem,
+                ),
+            )
+
+
+class DatOutput(TumorsphereOutput):
+    def __init__(self, culture_name):
+        self.filename = f"data/{culture_name}.dat"
+        with open(self.filename, "w") as datfile:
+            datfile.write("total, active, total_stem, active_stem \n")
+
+    def begin_culture(
+        self,
+        prob_stem,
+        prob_diff,
+        rng_seed,
+        simulation_start,
+        adjacency_threshold,
+        swap_probability,
+    ):
+        pass
+
+    def record_stemness(self, cell_index, tic, stemness):
+        pass
+
+    def record_deactivation(self, cell_index, tic):
+        pass
+
+    def record_num_cells(
+        self, num_cells, num_active, num_stem, num_active_stem
+    ):
+        with open(self.filename, "a") as datfile:
+            datfile.write(
+                f"{num_cells}, {num_active}, {num_stem}, {num_active_stem} \n"
+            )
+
+    def dump_cell_positions(self, t, cells, cell_positions):
+        pass
+
+    def record_cell(
+        self, index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+    ):
+        pass
+
+
+class OvitoOutput(TumorsphereOutput):
+    def __init__(self, culture_name):
+        self.culture_name = culture_name
+
+    def begin_culture(
+        self,
+        prob_stem,
+        prob_diff,
+        rng_seed,
+        simulation_start,
+        adjacency_threshold,
+        swap_probability,
+    ):
+        pass
+
+    def record_stemness(self, cell_index, tic, stemness):
+        pass
+
+    def record_deactivation(self, cell_index, tic):
+        pass
+
+    def record_num_cells(
+        self, num_cells, num_active, num_stem, num_active_stem
+    ):
+        pass
+
+    def dump_cell_positions(self, t, cells, cell_positions):
+        """Writes the data file in path for ovito, for time step t of self.
+        Auxiliar function for simulate_with_ovito_data.
+        """
+        path_to_write = f"data/ovito_data_{self.culture_name}.{t:03}"
+        with open(path_to_write, "w") as file_to_write:
+            file_to_write.write(str(len(cells)) + "\n")
+            file_to_write.write(
+                ' Lattice="1.0 0.0 0.0 0.0 1.0 0.0 0.0 0.0 1.0"Properties=species:S:1:pos:R:3:Color:r:1'
+                + "\n"
+            )
+
+            for cell in cells:  # csc activas
+                if cell.is_stem and cell.available_space:
+                    line = (
+                        "active_stem "
+                        + str(cell_positions[cell._index][0])
+                        + " "
+                        + str(cell_positions[cell._index][1])
+                        + " "
+                        + str(cell_positions[cell._index][2])
+                        + " "
+                        + "1"
+                        + "\n"
+                    )
+                    file_to_write.write(line)
+
+            for cell in cells:  # csc quiesc
+                if cell.is_stem and (not cell.available_space):
+                    line = (
+                        "quiesc_stem "
+                        + str(cell_positions[cell._index][0])
+                        + " "
+                        + str(cell_positions[cell._index][1])
+                        + " "
+                        + str(cell_positions[cell._index][2])
+                        + " "
+                        + "2"
+                        + "\n"
+                    )
+                    file_to_write.write(line)
+
+            for cell in cells:  # dcc activas
+                if (not cell.is_stem) and cell.available_space:
+                    line = (
+                        "active_diff "
+                        + str(cell_positions[cell._index][0])
+                        + " "
+                        + str(cell_positions[cell._index][1])
+                        + " "
+                        + str(cell_positions[cell._index][2])
+                        + " "
+                        + "3"
+                        + "\n"
+                    )
+                    file_to_write.write(line)
+
+            for cell in cells:  # dcc quiesc
+                if not (cell.is_stem or cell.available_space):
+                    line = (
+                        "quiesc_diff "
+                        + str(cell_positions[cell._index][0])
+                        + " "
+                        + str(cell_positions[cell._index][1])
+                        + " "
+                        + str(cell_positions[cell._index][2])
+                        + " "
+                        + "4"
+                        + "\n"
+                    )
+                    file_to_write.write(line)
+
+    def record_cell(
+        self, index, parent, pos_x, pos_y, pos_z, creation_time, is_stem
+    ):
+        pass
+
+
+def create_output_demux(
+    culture_name: str,
+    requested_outputs: list[str],
+):
+    output_types = {
+        "sql": SQLOutput,
+        "dat": DatOutput,
+        "ovito": OvitoOutput,
+    }
+    outputs = []
+    for out in requested_outputs:
+        if out in output_types:
+            outputs.append(output_types[out](culture_name))
+        else:
+            logging.warning(f"Invalid output {out} requested")
+    return OutputDemux(culture_name, outputs)

--- a/tumorsphere/core/simulation.py
+++ b/tumorsphere/core/simulation.py
@@ -12,7 +12,7 @@ from typing import Tuple
 import numpy as np
 
 from tumorsphere.core.culture import Culture
-from tumorsphere.core.output import *
+from tumorsphere.core.output import create_output_demux
 
 
 class Simulation:
@@ -147,7 +147,9 @@ class Simulation:
             low=2**20, high=2**50, size=self.num_of_realizations
         )
 
-        outputs = ["sql"]
+        outputs = []
+        if sql:
+            outputs.append("sql")
         if dat_files:
             outputs.append("dat")
         if ovito:

--- a/tumorsphere/core/simulation.py
+++ b/tumorsphere/core/simulation.py
@@ -12,6 +12,7 @@ from typing import Tuple
 import numpy as np
 
 from tumorsphere.core.culture import Culture
+from tumorsphere.core.output import *
 
 
 class Simulation:
@@ -108,6 +109,7 @@ class Simulation:
 
     def simulate_parallel(
         self,
+        sql: bool = True,
         ovito: bool = False,
         dat_files: bool = False,
         number_of_processes: int = None,
@@ -145,42 +147,37 @@ class Simulation:
             low=2**20, high=2**50, size=self.num_of_realizations
         )
 
+        outputs = ["sql"]
+        if dat_files:
+            outputs.append("dat")
         if ovito:
-            with mp.Pool(number_of_processes) as p:
-                p.map(
-                    simulate_single_culture_ovito,
-                    [
-                        (k, i, seeds[j], self)
-                        for k in range(len(self.prob_diff))
-                        for i in range(len(self.prob_stem))
-                        for j in range(self.num_of_realizations)
-                    ],
-                )
-        elif dat_files:
-            with mp.Pool(number_of_processes) as p:
-                p.map(
-                    simulate_single_culture_dat_files,
-                    [
-                        (k, i, seeds[j], self)
-                        for k in range(len(self.prob_diff))
-                        for i in range(len(self.prob_stem))
-                        for j in range(self.num_of_realizations)
-                    ],
-                )
-        else:
-            with mp.Pool(number_of_processes) as p:
-                p.map(
-                    simulate_single_culture,
-                    [
-                        (k, i, seeds[j], self)
-                        for k in range(len(self.prob_diff))
-                        for i in range(len(self.prob_stem))
-                        for j in range(self.num_of_realizations)
-                    ],
-                )
+            outputs.append("ovito")
+
+        with mp.Pool(number_of_processes) as p:
+            p.map(
+                simulate_single_culture,
+                [
+                    (
+                        k,
+                        i,
+                        seeds[j],
+                        self,
+                        outputs,
+                    )
+                    for k in range(len(self.prob_diff))
+                    for i in range(len(self.prob_stem))
+                    for j in range(self.num_of_realizations)
+                ],
+            )
 
 
-def simulate_single_culture(args: Tuple[int, int, int, Simulation]) -> None:
+def realization_name(pd, ps, seed) -> str:
+    return f"culture_pd={pd}_ps={ps}_rng_seed={seed}"
+
+
+def simulate_single_culture(
+    args: Tuple[int, int, int, Simulation, dict[str, bool]]
+) -> None:
     """A worker function for multiprocessing.
 
     This function is used by the multiprocessing.Pool instance in the
@@ -203,11 +200,14 @@ def simulate_single_culture(args: Tuple[int, int, int, Simulation]) -> None:
     methods can't be pickled. Therefore, the instance method worker had to be
     refactored to a standalone function (or a static method).
     """
-    k, i, seed, sim = args
-    current_realization_name = (
-        f"culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}"
+    k, i, seed, sim, outputs = args
+
+    current_realization_name = realization_name(
+        sim.prob_diff[k], sim.prob_stem[i], seed
     )
+    output = create_output_demux(current_realization_name, outputs)
     sim.cultures[current_realization_name] = Culture(
+        output,
         adjacency_threshold=sim.adjacency_threshold,
         cell_radius=sim.cell_radius,
         cell_max_repro_attempts=sim.cell_max_repro_attempts,
@@ -219,96 +219,4 @@ def simulate_single_culture(args: Tuple[int, int, int, Simulation]) -> None:
     )
     sim.cultures[current_realization_name].simulate(
         sim.num_of_steps_per_realization,
-        current_realization_name,
-    )
-
-
-def simulate_single_culture_dat_files(
-    args: Tuple[int, int, int, Simulation]
-) -> None:
-    """Copy of simulate_single_culture that outputs `.dat` files with
-    population numbers only. A worker function for multiprocessing.
-
-    This function is used by the multiprocessing.Pool instance in the
-    simulate_parallel method to parallelize the simulation of different
-    cultures. This simulates the growth of a single culture with the given
-    parameters and persist the data.
-
-    Parameters
-    ----------
-    args : tuple
-        A tuple containing the indices for the self-replication probability,
-        differentiation probability, the seed to be used in the random number
-        generator of the culture, and the instance of the Simulation class.
-
-    Notes
-    -----
-    Due to the way multiprocessing works in Python, you can't directly use
-    instance methods as workers for multiprocessing. The multiprocessing
-    module needs to be able to pickle the target function, and instance
-    methods can't be pickled. Therefore, the instance method worker had to be
-    refactored to a standalone function (or a static method).
-    """
-    k, i, seed, sim = args
-    current_realization_name = (
-        f"culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}"
-    )
-    sim.cultures[current_realization_name] = Culture(
-        adjacency_threshold=sim.adjacency_threshold,
-        cell_radius=sim.cell_radius,
-        cell_max_repro_attempts=sim.cell_max_repro_attempts,
-        first_cell_is_stem=sim.first_cell_is_stem,
-        prob_stem=sim.prob_stem[i],
-        prob_diff=sim.prob_diff[k],
-        rng_seed=seed,
-        swap_probability=sim.swap_probability,
-    )
-    sim.cultures[current_realization_name].simulate_with_dat_files(
-        sim.num_of_steps_per_realization,
-        current_realization_name,
-    )
-
-
-def simulate_single_culture_ovito(
-    args: Tuple[int, int, int, Simulation]
-) -> None:
-    """Copy of simulate_single_culture for Ovito plotting. A worker function
-    for multiprocessing.
-
-    This function is used by the multiprocessing.Pool instance in the
-    simulate_parallel method to parallelize the simulation of different
-    cultures. This simulates the growth of a single culture with the given
-    parameters and persist the data.
-
-    Parameters
-    ----------
-    args : tuple
-        A tuple containing the indices for the self-replication probability,
-        differentiation probability, the seed to be used in the random number
-        generator of the culture, and the instance of the Simulation class.
-
-    Notes
-    -----
-    Due to the way multiprocessing works in Python, you can't directly use
-    instance methods as workers for multiprocessing. The multiprocessing
-    module needs to be able to pickle the target function, and instance
-    methods can't be pickled. Therefore, the instance method worker had to be
-    refactored to a standalone function (or a static method).
-    """
-    k, i, seed, sim = args
-    current_realization_name = (
-        f"culture_pd={sim.prob_diff[k]}_ps={sim.prob_stem[i]}_rng_seed={seed}"
-    )
-    sim.cultures[current_realization_name] = Culture(
-        adjacency_threshold=sim.adjacency_threshold,
-        cell_radius=sim.cell_radius,
-        cell_max_repro_attempts=sim.cell_max_repro_attempts,
-        first_cell_is_stem=sim.first_cell_is_stem,
-        prob_stem=sim.prob_stem[i],
-        prob_diff=sim.prob_diff[k],
-        rng_seed=seed,
-    )
-    sim.cultures[current_realization_name].simulate_with_ovito_data(
-        sim.num_of_steps_per_realization,
-        current_realization_name,
     )


### PR DESCRIPTION
Merge the various `simulate_with_*` functions back into a single implementation that takes a generic `TumorsphereOutput` abstract base class for output. There are 3 derived classes that implement the previous functionality (SQL, dat and ovito) and an `OutputDemux` class that allows multiple outputs to be selected.