### PR TITLE
Spatial hash tweaks

### DIFF
--- a/tumorsphere/core/culture.py
+++ b/tumorsphere/core/culture.py
@@ -193,8 +193,10 @@ class Culture:
 
                 # set of all existing cell indexes that would neighbor the new
                 # cell
-                neighbor_indices = self.grid.find_neighbors(
-                    position=child_position,
+                neighbor_indices = list(
+                    self.grid.find_neighbors(
+                        position=child_position,
+                    )
                 )
                 # modifies the set in-place to remove the parent cell index
                 neighbor_indices.remove(cell_index)
@@ -202,7 +204,6 @@ class Culture:
                 # array with the distances from the proposed child position to
                 # the other cells
                 if len(neighbor_indices) > 0:
-                    neighbor_indices = list(neighbor_indices)
                     neighbor_position_mat = self.cell_positions[
                         neighbor_indices, :
                     ]

--- a/tumorsphere/core/spatial_hash_grid.py
+++ b/tumorsphere/core/spatial_hash_grid.py
@@ -2,6 +2,7 @@
 
 from itertools import product
 from typing import Tuple
+from collections import defaultdict
 
 import numpy as np
 
@@ -53,7 +54,7 @@ class SpatialHashGrid:
         self.bounds = bounds
         self.cube_size = cube_size
         self.offsets = np.array(list(product(range(-1, 2), repeat=3)))
-        self.hash_table = {}
+        self.hash_table = defaultdict(set)
 
     def get_hash_key(
         self,
@@ -68,10 +69,7 @@ class SpatialHashGrid:
         position: np.ndarray,
     ) -> None:
         """Add a cell to the hash table."""
-        hash_key = self.get_hash_key(position)
-        if hash_key not in self.hash_table:
-            self.hash_table[hash_key] = set()
-        self.hash_table[hash_key].add(cell_index)
+        self.hash_table[self.get_hash_key(position)].add(cell_index)
 
     def remove_cell_from_hash_table(
         self,
@@ -79,9 +77,7 @@ class SpatialHashGrid:
         position: np.ndarray,
     ) -> None:
         """Remove a cell from the hash table."""
-        hash_key = self.get_hash_key(position)
-        if hash_key in self.hash_table:
-            self.hash_table[hash_key].remove(cell_index)
+        self.hash_table[self.get_hash_key(position)].remove(cell_index)
 
     def is_position_in_bounds(
         self,
@@ -172,7 +168,6 @@ class SpatialHashGrid:
 
         # Convert array of keys to tuples and filter valid keys
         for adj_key in map(tuple, adj_keys):  # Convert once and iterate
-            if adj_key in self.hash_table:
-                neighbors.update(self.hash_table[adj_key])
+            neighbors.update(self.hash_table[adj_key])
 
         return neighbors


### PR DESCRIPTION
- Use defaultdict(set) as spatial hash table
- Use byte representation of bucket position ndarray as immutable to hash in spatial_hash
- Return an iterable in find_neighbors to avoid a set->list conversion